### PR TITLE
Refactor targets

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -4,3 +4,5 @@
 .Ruserdata
 
 _targets/*
+1_fetch/out/
+3_visualize/out/

--- a/1_fetch/src/get_nwis_data.R
+++ b/1_fetch/src/get_nwis_data.R
@@ -15,7 +15,7 @@ nwis_site_info <- function(fileout, site_data){
 }
 
 
-download_nwis_site_data <- function(filepath, parameterCd = '00010', startDate="2014-05-01", endDate="2015-05-01"){
+download_nwis_site_data <- function(filepath, parameterCd, startDate, endDate){
   
   # filepaths look something like directory/nwis_01432160_data.csv,
   # remove the directory with basename() and extract the 01432160 with the regular expression match

--- a/1_fetch/src/get_nwis_data.R
+++ b/1_fetch/src/get_nwis_data.R
@@ -1,19 +1,10 @@
-
-download_nwis_data <- function(site_nums = c("01427207", "01432160", "01435000", "01436690", "01466500")){
-  
-  # create the file names that are needed for download_nwis_site_data
-  # tempdir() creates a temporary directory that is wiped out when you start a new R session; 
-  # replace tempdir() with "1_fetch/out" or another desired folder if you want to retain the download
-  download_files <- file.path(tempdir(), paste0('nwis_', site_nums, '_data.csv'))
+combine_nwis_site_data <- function(site_csvs) {
   data_out <- data.frame()
-  # loop through files to download 
-  for (download_file in download_files){
-    download_nwis_site_data(download_file, parameterCd = '00010')
-    # read the downloaded data and append it to the existing data.frame
-    these_data <- read_csv(download_file, col_types = 'ccTdcc')
+  for (site_csv in site_csvs) {
+    these_data <- read_csv(site_csv, col_types = 'ccTdcc')
     data_out <- bind_rows(data_out, these_data)
   }
-  return(data_out)
+  data_out
 }
 
 nwis_site_info <- function(fileout, site_data){

--- a/2_process/src/process_and_style.R
+++ b/2_process/src/process_and_style.R
@@ -1,19 +1,16 @@
-process_data <- function(nwis_data){
-  nwis_data_clean <- rename(nwis_data, water_temperature = X_00010_00000) %>% 
-    select(-agency_cd, -X_00010_00000_cd, -tz_cd)
-  
-  return(nwis_data_clean)
-}
-
-annotate_data <- function(site_data_clean, site_filename){
+# standardize column names, add site metadata, drop unnecessary columns
+process_data <- function(nwis_data, site_filename) {
   site_info <- read_csv(site_filename)
-  annotated_data <- left_join(site_data_clean, site_info, by = "site_no") %>% 
-    select(station_name = station_nm, site_no, dateTime, water_temperature, latitude = dec_lat_va, longitude = dec_long_va)
-  
-  return(annotated_data)
-}
-
-
-style_data <- function(site_data_annotated){
-  mutate(site_data_annotated, station_name = as.factor(station_name))
+  site_data_styled <- nwis_data %>%
+    rename(water_temperature = X_00010_00000) %>% 
+    select(-agency_cd, -X_00010_00000_cd, -tz_cd) %>%
+    left_join(site_info, by = "site_no") %>% 
+    select(station_name = station_nm,
+           site_no,
+           dateTime,
+           water_temperature,
+           latitude = dec_lat_va,
+           longitude = dec_long_va) %>%
+    mutate(station_name = as.factor(station_name))
+  site_data_styled
 }

--- a/_targets.R
+++ b/_targets.R
@@ -6,10 +6,44 @@ source("3_visualize/src/plot_timeseries.R")
 options(tidyverse.quiet = TRUE)
 tar_option_set(packages = c("tidyverse", "dataRetrieval")) # Loading tidyverse because we need dplyr, ggplot2, readr, stringr, and purrr
 
+p_width <- 12
+p_height <- 7
+p_units <- "in"
 p1_targets_list <- list(
   tar_target(
+    site_data_01427207_csv,
+    download_nwis_site_data(filepath =  "1_fetch/out/nwis_01427207_data.csv"),
+    format = "file",
+  ),
+  tar_target(
+    site_data_01432160_csv,
+    download_nwis_site_data(filepath =  "1_fetch/out/nwis_01432160_data.csv"),
+    format = "file",
+  ),
+  tar_target(
+    site_data_01435000_csv,
+    download_nwis_site_data(filepath =  "1_fetch/out/nwis_01435000_data.csv"),
+    format = "file",
+  ),
+  tar_target(
+    site_data_01436690_csv,
+    download_nwis_site_data(filepath =  "1_fetch/out/nwis_01436690_data.csv"),
+    format = "file",
+  ),
+  tar_target(
+    site_data_01466500_csv,
+    download_nwis_site_data(filepath =  "1_fetch/out/nwis_01466500_data.csv"),
+    format = "file",
+  ),
+  tar_target(
     site_data,
-    download_nwis_data(),
+    combine_nwis_site_data(site_csvs = c(site_data_01427207_csv,
+                                         site_data_01432160_csv,
+                                         site_data_01435000_csv,
+                                         site_data_01436690_csv,
+                                         site_data_01466500_csv
+                                         )
+                           )
   ),
   tar_target(
     site_info_csv,
@@ -36,7 +70,8 @@ p2_targets_list <- list(
 p3_targets_list <- list(
   tar_target(
     figure_1_png,
-    plot_nwis_timeseries(fileout = "3_visualize/out/figure_1.png", site_data_styled),
+    plot_nwis_timeseries(fileout = "3_visualize/out/figure_1.png", site_data_styled,
+                         width = p_width, height = p_height, units = p_units),
     format = "file"
   )
 )

--- a/_targets.R
+++ b/_targets.R
@@ -9,30 +9,49 @@ tar_option_set(packages = c("tidyverse", "dataRetrieval")) # Loading tidyverse b
 p_width <- 12
 p_height <- 7
 p_units <- "in"
+parameterCd = '00010'
+startDate="2014-05-01"
+endDate="2015-05-01"
+
 p1_targets_list <- list(
   tar_target(
     site_data_01427207_csv,
-    download_nwis_site_data(filepath =  "1_fetch/out/nwis_01427207_data.csv"),
+    download_nwis_site_data(filepath =  "1_fetch/out/nwis_01427207_data.csv",
+                            parameterCd = parameterCd,
+                            startDate = startDate,
+                            endDate = endDate),
     format = "file",
   ),
   tar_target(
     site_data_01432160_csv,
-    download_nwis_site_data(filepath =  "1_fetch/out/nwis_01432160_data.csv"),
+    download_nwis_site_data(filepath =  "1_fetch/out/nwis_01432160_data.csv",
+                            parameterCd = parameterCd,
+                            startDate = startDate,
+                            endDate = endDate),
     format = "file",
   ),
   tar_target(
     site_data_01435000_csv,
-    download_nwis_site_data(filepath =  "1_fetch/out/nwis_01435000_data.csv"),
+    download_nwis_site_data(filepath =  "1_fetch/out/nwis_01435000_data.csv",
+                            parameterCd = parameterCd,
+                            startDate = startDate,
+                            endDate = endDate),
     format = "file",
   ),
   tar_target(
     site_data_01436690_csv,
-    download_nwis_site_data(filepath =  "1_fetch/out/nwis_01436690_data.csv"),
+    download_nwis_site_data(filepath =  "1_fetch/out/nwis_01436690_data.csv",
+                            parameterCd = parameterCd,
+                            startDate = startDate,
+                            endDate = endDate),
     format = "file",
   ),
   tar_target(
     site_data_01466500_csv,
-    download_nwis_site_data(filepath =  "1_fetch/out/nwis_01466500_data.csv"),
+    download_nwis_site_data(filepath =  "1_fetch/out/nwis_01466500_data.csv",
+                            parameterCd = parameterCd,
+                            startDate = startDate,
+                            endDate = endDate),
     format = "file",
   ),
   tar_target(

--- a/_targets.R
+++ b/_targets.R
@@ -54,16 +54,8 @@ p1_targets_list <- list(
 
 p2_targets_list <- list(
   tar_target(
-    site_data_clean, 
-    process_data(site_data)
-  ),
-  tar_target(
-    site_data_annotated,
-    annotate_data(site_data_clean, site_filename = site_info_csv)
-  ),
-  tar_target(
-    site_data_styled,
-    style_data(site_data_annotated)
+    site_data_styled, 
+    process_data(site_data, site_filename = site_info_csv)
   )
 )
 


### PR DESCRIPTION
This PR improves the pipeline as per #5 

1. The `2_process` phase of the pipeline by combining several unnecessarily short targets into one, simplifying the code and the DAG
2. The `1_fetch` phase of the pipeline by adding fault tolerance. The NWIS site data downloads were failing 3/4 of the time, making it very difficult for the `download_nwis_data` to run to completion and meaning that the same files might be downloaded many times. I have created a single target for each file, meaning that it is only downloaded once.

This approach has two weaknesses. First, the pipeline will usually still need to be run several times in order to run to completion. Second, if we were to start more NWIS data downloads to the analysis, having a separate target for each download would become cumbersome. If either of these issues is a problem, it might make more sense to switch to a design where the `2_process` phase of the pipeline depends on the entire directory of NWIS files, and the `1_fetch` phase implements a loop with some fault tolerance to try to download all of the files in a list.