### PR TITLE
Swap targets

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -5,4 +5,5 @@
 
 _targets/*
 1_fetch/out/
+2_process/out/
 3_visualize/out/

--- a/1_fetch/src/get_nwis_data.R
+++ b/1_fetch/src/get_nwis_data.R
@@ -1,12 +1,3 @@
-combine_nwis_site_data <- function(site_csvs) {
-  data_out <- data.frame()
-  for (site_csv in site_csvs) {
-    these_data <- read_csv(site_csv, col_types = 'ccTdcc')
-    data_out <- bind_rows(data_out, these_data)
-  }
-  data_out
-}
-
 nwis_site_info <- function(fileout, site_data){
   site_no <- unique(site_data$site_no)
   site_info <- dataRetrieval::readNWISsite(site_no)
@@ -15,13 +6,7 @@ nwis_site_info <- function(fileout, site_data){
 }
 
 
-download_nwis_site_data <- function(filepath, parameterCd, startDate, endDate){
-  
-  # filepaths look something like directory/nwis_01432160_data.csv,
-  # remove the directory with basename() and extract the 01432160 with the regular expression match
-  site_num <- basename(filepath) %>% 
-    stringr::str_extract(pattern = "(?:[0-9]+)")
-  
+download_nwis_site_data <- function(site_num, parameterCd, startDate, endDate){
   # readNWISdata is from the dataRetrieval package
   data_out <- readNWISdata(sites=site_num, service="iv", 
                            parameterCd = parameterCd, startDate = startDate, endDate = endDate)
@@ -33,7 +18,6 @@ download_nwis_site_data <- function(filepath, parameterCd, startDate, endDate){
   }
   # -- end of do-not-edit block
   
-  write_csv(data_out, file = filepath)
-  return(filepath)
+  data_out
 }
 

--- a/2_process/src/process_and_style.R
+++ b/2_process/src/process_and_style.R
@@ -1,5 +1,5 @@
 # standardize column names, add site metadata, drop unnecessary columns
-process_data <- function(nwis_data, site_filename) {
+process_data <- function(nwis_data, site_filename, fileout) {
   site_info <- read_csv(site_filename)
   site_data_styled <- nwis_data %>%
     rename(water_temperature = X_00010_00000) %>% 
@@ -12,5 +12,6 @@ process_data <- function(nwis_data, site_filename) {
            latitude = dec_lat_va,
            longitude = dec_long_va) %>%
     mutate(station_name = as.factor(station_name))
-  site_data_styled
+  write_feather(site_data_styled, fileout)
+  fileout
 }

--- a/3_visualize/src/plot_timeseries.R
+++ b/3_visualize/src/plot_timeseries.R
@@ -1,5 +1,6 @@
 plot_nwis_timeseries <- function(fileout, site_data_styled, width = 12, height = 7, units = 'in'){
   
+  site_data_styled = read_feather(site_data_styled)
   ggplot(data = site_data_styled, aes(x = dateTime, y = water_temperature, color = station_name)) +
     geom_line() + theme_bw()
   ggsave(fileout, width = width, height = height, units = units)

--- a/3_visualize/src/plot_timeseries.R
+++ b/3_visualize/src/plot_timeseries.R
@@ -1,6 +1,6 @@
 plot_nwis_timeseries <- function(fileout, site_data_styled, width = 12, height = 7, units = 'in'){
   
-  site_data_styled = read_feather(site_data_styled)
+  site_data_styled <- read_feather(site_data_styled)
   ggplot(data = site_data_styled, aes(x = dateTime, y = water_temperature, color = station_name)) +
     geom_line() + theme_bw()
   ggsave(fileout, width = width, height = height, units = units)

--- a/3_visualize/src/plot_timeseries.R
+++ b/3_visualize/src/plot_timeseries.R
@@ -1,6 +1,6 @@
-plot_nwis_timeseries <- function(fileout, site_data_styled, width = 12, height = 7, units = 'in'){
+plot_nwis_timeseries <- function(fileout, site_data_styled_file, width = 12, height = 7, units = 'in'){
   
-  site_data_styled <- read_feather(site_data_styled)
+  site_data_styled <- read_feather(site_data_styled_file)
   ggplot(data = site_data_styled, aes(x = dateTime, y = water_temperature, color = station_name)) +
     geom_line() + theme_bw()
   ggsave(fileout, width = width, height = height, units = units)

--- a/_targets.R
+++ b/_targets.R
@@ -15,54 +15,49 @@ endDate="2015-05-01"
 
 p1_targets_list <- list(
   tar_target(
-    site_data_01427207_csv,
-    download_nwis_site_data(filepath =  "1_fetch/out/nwis_01427207_data.csv",
+    site_data_01427207,
+    download_nwis_site_data(site_num =  "01427207",
                             parameterCd = parameterCd,
                             startDate = startDate,
                             endDate = endDate),
-    format = "file",
   ),
   tar_target(
-    site_data_01432160_csv,
-    download_nwis_site_data(filepath =  "1_fetch/out/nwis_01432160_data.csv",
+    site_data_01432160,
+    download_nwis_site_data(site_num =  "01432160",
                             parameterCd = parameterCd,
                             startDate = startDate,
                             endDate = endDate),
-    format = "file",
   ),
   tar_target(
-    site_data_01435000_csv,
-    download_nwis_site_data(filepath =  "1_fetch/out/nwis_01435000_data.csv",
+    site_data_01435000,
+    download_nwis_site_data(site_num =  "01435000",
                             parameterCd = parameterCd,
                             startDate = startDate,
                             endDate = endDate),
-    format = "file",
   ),
   tar_target(
-    site_data_01436690_csv,
-    download_nwis_site_data(filepath =  "1_fetch/out/nwis_01436690_data.csv",
+    site_data_01436690,
+    download_nwis_site_data(site_num =  "01436690",
                             parameterCd = parameterCd,
                             startDate = startDate,
                             endDate = endDate),
-    format = "file",
   ),
   tar_target(
-    site_data_01466500_csv,
-    download_nwis_site_data(filepath =  "1_fetch/out/nwis_01466500_data.csv",
+    site_data_01466500,
+    download_nwis_site_data(site_num =  "01466500",
                             parameterCd = parameterCd,
                             startDate = startDate,
                             endDate = endDate),
-    format = "file",
   ),
   tar_target(
     site_data,
-    combine_nwis_site_data(site_csvs = c(site_data_01427207_csv,
-                                         site_data_01432160_csv,
-                                         site_data_01435000_csv,
-                                         site_data_01436690_csv,
-                                         site_data_01466500_csv
-                                         )
-                           )
+    bind_rows(list(site_data_01427207,
+                   site_data_01432160,
+                   site_data_01435000,
+                   site_data_01436690,
+                   site_data_01466500
+                  )
+             )
   ),
   tar_target(
     site_info_csv,

--- a/_targets.R
+++ b/_targets.R
@@ -81,7 +81,7 @@ p3_targets_list <- list(
   tar_target(
     figure_1_png,
     plot_nwis_timeseries(fileout = "3_visualize/out/figure_1.png",
-                         site_data_styled = site_data_styled_feather,
+                         site_data_styled_file = site_data_styled_feather,
                          width = p_width,
                          height = p_height,
                          units = p_units),

--- a/_targets.R
+++ b/_targets.R
@@ -3,8 +3,9 @@ source("1_fetch/src/get_nwis_data.R")
 source("2_process/src/process_and_style.R")
 source("3_visualize/src/plot_timeseries.R")
 
+# Loading tidyverse because we need dplyr, ggplot2, readr, stringr, and purrr
 options(tidyverse.quiet = TRUE)
-tar_option_set(packages = c("tidyverse", "dataRetrieval")) # Loading tidyverse because we need dplyr, ggplot2, readr, stringr, and purrr
+tar_option_set(packages = c("tidyverse", "dataRetrieval", "arrow"))
 
 p_width <- 12
 p_height <- 7
@@ -68,16 +69,22 @@ p1_targets_list <- list(
 
 p2_targets_list <- list(
   tar_target(
-    site_data_styled, 
-    process_data(site_data, site_filename = site_info_csv)
+    site_data_styled_feather, 
+    process_data(site_data,
+                 site_filename = site_info_csv,
+                 fileout = "2_process/out/site_data_styled.feather"),
+    format = "file"
   )
 )
 
 p3_targets_list <- list(
   tar_target(
     figure_1_png,
-    plot_nwis_timeseries(fileout = "3_visualize/out/figure_1.png", site_data_styled,
-                         width = p_width, height = p_height, units = p_units),
+    plot_nwis_timeseries(fileout = "3_visualize/out/figure_1.png",
+                         site_data_styled = site_data_styled_feather,
+                         width = p_width,
+                         height = p_height,
+                         units = p_units),
     format = "file"
   )
 )

--- a/_targets.R
+++ b/_targets.R
@@ -10,9 +10,9 @@ tar_option_set(packages = c("tidyverse", "dataRetrieval", "arrow"))
 p_width <- 12
 p_height <- 7
 p_units <- "in"
-parameterCd = '00010'
-startDate="2014-05-01"
-endDate="2015-05-01"
+parameterCd <- '00010'
+startDate <- "2014-05-01"
+endDate <- "2015-05-01"
 
 p1_targets_list <- list(
   tar_target(


### PR DESCRIPTION
1. The individual file downloads now use object storage rather than CSV. This allows us more assurance that datetimes won't get mucked up. It also allows us to remove the hack where the site number was being extracted from the filename with a regex. This kind of hack could eventually lead to bugs if filenames contained more than once sequence of numbers.
2. The combined and styled data is now saved as a feather file rather than using object storage. We can now share this file with collaborators using python so that they can also visualize the data.