### PR TITLE
Use phases

### DIFF
--- a/1_fetch.R
+++ b/1_fetch.R
@@ -2,53 +2,53 @@ source("1_fetch/src/get_nwis_data.R")
 
 p1_targets_list <- list(
   tar_target(
-    site_data_01427207,
+    p1_site_data_01427207,
     download_nwis_site_data(site_num =  "01427207",
                             parameterCd = parameterCd,
                             startDate = startDate,
                             endDate = endDate),
   ),
   tar_target(
-    site_data_01432160,
+    p1_site_data_01432160,
     download_nwis_site_data(site_num =  "01432160",
                             parameterCd = parameterCd,
                             startDate = startDate,
                             endDate = endDate),
   ),
   tar_target(
-    site_data_01435000,
+    p1_site_data_01435000,
     download_nwis_site_data(site_num =  "01435000",
                             parameterCd = parameterCd,
                             startDate = startDate,
                             endDate = endDate),
   ),
   tar_target(
-    site_data_01436690,
+    p1_site_data_01436690,
     download_nwis_site_data(site_num =  "01436690",
                             parameterCd = parameterCd,
                             startDate = startDate,
                             endDate = endDate),
   ),
   tar_target(
-    site_data_01466500,
+    p1_site_data_01466500,
     download_nwis_site_data(site_num =  "01466500",
                             parameterCd = parameterCd,
                             startDate = startDate,
                             endDate = endDate),
   ),
   tar_target(
-    site_data,
-    bind_rows(list(site_data_01427207,
-                   site_data_01432160,
-                   site_data_01435000,
-                   site_data_01436690,
-                   site_data_01466500
+    p1_site_data,
+    bind_rows(list(p1_site_data_01427207,
+                   p1_site_data_01432160,
+                   p1_site_data_01435000,
+                   p1_site_data_01436690,
+                   p1_site_data_01466500
                   )
              )
   ),
   tar_target(
-    site_info_csv,
-    nwis_site_info(fileout = "1_fetch/out/site_info.csv", site_data),
+    p1_site_info_csv,
+    nwis_site_info(fileout = "1_fetch/out/site_info.csv", p1_site_data),
     format = "file"
   )
 )

--- a/1_fetch.R
+++ b/1_fetch.R
@@ -1,5 +1,9 @@
 source("1_fetch/src/get_nwis_data.R")
 
+parameterCd <- '00010'
+startDate <- "2014-05-01"
+endDate <- "2015-05-01"
+
 p1_targets_list <- list(
   tar_target(
     p1_site_data_01427207,

--- a/1_fetch.R
+++ b/1_fetch.R
@@ -1,0 +1,54 @@
+source("1_fetch/src/get_nwis_data.R")
+
+p1_targets_list <- list(
+  tar_target(
+    site_data_01427207,
+    download_nwis_site_data(site_num =  "01427207",
+                            parameterCd = parameterCd,
+                            startDate = startDate,
+                            endDate = endDate),
+  ),
+  tar_target(
+    site_data_01432160,
+    download_nwis_site_data(site_num =  "01432160",
+                            parameterCd = parameterCd,
+                            startDate = startDate,
+                            endDate = endDate),
+  ),
+  tar_target(
+    site_data_01435000,
+    download_nwis_site_data(site_num =  "01435000",
+                            parameterCd = parameterCd,
+                            startDate = startDate,
+                            endDate = endDate),
+  ),
+  tar_target(
+    site_data_01436690,
+    download_nwis_site_data(site_num =  "01436690",
+                            parameterCd = parameterCd,
+                            startDate = startDate,
+                            endDate = endDate),
+  ),
+  tar_target(
+    site_data_01466500,
+    download_nwis_site_data(site_num =  "01466500",
+                            parameterCd = parameterCd,
+                            startDate = startDate,
+                            endDate = endDate),
+  ),
+  tar_target(
+    site_data,
+    bind_rows(list(site_data_01427207,
+                   site_data_01432160,
+                   site_data_01435000,
+                   site_data_01436690,
+                   site_data_01466500
+                  )
+             )
+  ),
+  tar_target(
+    site_info_csv,
+    nwis_site_info(fileout = "1_fetch/out/site_info.csv", site_data),
+    format = "file"
+  )
+)

--- a/2_process.R
+++ b/2_process.R
@@ -2,9 +2,9 @@ source("2_process/src/process_and_style.R")
 
 p2_targets_list <- list(
   tar_target(
-    site_data_styled_feather, 
-    process_data(site_data,
-                 site_filename = site_info_csv,
+    p2_site_data_styled_feather, 
+    process_data(p1_site_data,
+                 site_filename = p1_site_info_csv,
                  fileout = "2_process/out/site_data_styled.feather"),
     format = "file"
   )

--- a/2_process.R
+++ b/2_process.R
@@ -1,0 +1,11 @@
+source("2_process/src/process_and_style.R")
+
+p2_targets_list <- list(
+  tar_target(
+    site_data_styled_feather, 
+    process_data(site_data,
+                 site_filename = site_info_csv,
+                 fileout = "2_process/out/site_data_styled.feather"),
+    format = "file"
+  )
+)

--- a/3_visualize.R
+++ b/3_visualize.R
@@ -1,0 +1,13 @@
+source("3_visualize/src/plot_timeseries.R")
+
+p3_targets_list <- list(
+  tar_target(
+    figure_1_png,
+    plot_nwis_timeseries(fileout = "3_visualize/out/figure_1.png",
+                         site_data_styled_file = site_data_styled_feather,
+                         width = p_width,
+                         height = p_height,
+                         units = p_units),
+    format = "file"
+  )
+)

--- a/3_visualize.R
+++ b/3_visualize.R
@@ -1,5 +1,9 @@
 source("3_visualize/src/plot_timeseries.R")
 
+p_width <- 12
+p_height <- 7
+p_units <- "in"
+
 p3_targets_list <- list(
   tar_target(
     p3_figure_1_png,

--- a/3_visualize.R
+++ b/3_visualize.R
@@ -2,9 +2,9 @@ source("3_visualize/src/plot_timeseries.R")
 
 p3_targets_list <- list(
   tar_target(
-    figure_1_png,
+    p3_figure_1_png,
     plot_nwis_timeseries(fileout = "3_visualize/out/figure_1.png",
-                         site_data_styled_file = site_data_styled_feather,
+                         site_data_styled_file = p2_site_data_styled_feather,
                          width = p_width,
                          height = p_height,
                          units = p_units),

--- a/_targets.R
+++ b/_targets.R
@@ -4,13 +4,6 @@ library(targets)
 options(tidyverse.quiet = TRUE)
 tar_option_set(packages = c("tidyverse", "dataRetrieval", "arrow"))
 
-p_width <- 12
-p_height <- 7
-p_units <- "in"
-parameterCd <- '00010'
-startDate <- "2014-05-01"
-endDate <- "2015-05-01"
-
 source("1_fetch.R")
 source("2_process.R")
 source("3_visualize.R")

--- a/_targets.R
+++ b/_targets.R
@@ -1,7 +1,4 @@
 library(targets)
-source("1_fetch/src/get_nwis_data.R")
-source("2_process/src/process_and_style.R")
-source("3_visualize/src/plot_timeseries.R")
 
 # Loading tidyverse because we need dplyr, ggplot2, readr, stringr, and purrr
 options(tidyverse.quiet = TRUE)
@@ -14,80 +11,8 @@ parameterCd <- '00010'
 startDate <- "2014-05-01"
 endDate <- "2015-05-01"
 
-p1_targets_list <- list(
-  tar_target(
-    site_data_01427207,
-    download_nwis_site_data(site_num =  "01427207",
-                            parameterCd = parameterCd,
-                            startDate = startDate,
-                            endDate = endDate),
-  ),
-  tar_target(
-    site_data_01432160,
-    download_nwis_site_data(site_num =  "01432160",
-                            parameterCd = parameterCd,
-                            startDate = startDate,
-                            endDate = endDate),
-  ),
-  tar_target(
-    site_data_01435000,
-    download_nwis_site_data(site_num =  "01435000",
-                            parameterCd = parameterCd,
-                            startDate = startDate,
-                            endDate = endDate),
-  ),
-  tar_target(
-    site_data_01436690,
-    download_nwis_site_data(site_num =  "01436690",
-                            parameterCd = parameterCd,
-                            startDate = startDate,
-                            endDate = endDate),
-  ),
-  tar_target(
-    site_data_01466500,
-    download_nwis_site_data(site_num =  "01466500",
-                            parameterCd = parameterCd,
-                            startDate = startDate,
-                            endDate = endDate),
-  ),
-  tar_target(
-    site_data,
-    bind_rows(list(site_data_01427207,
-                   site_data_01432160,
-                   site_data_01435000,
-                   site_data_01436690,
-                   site_data_01466500
-                  )
-             )
-  ),
-  tar_target(
-    site_info_csv,
-    nwis_site_info(fileout = "1_fetch/out/site_info.csv", site_data),
-    format = "file"
-  )
-)
+source("1_fetch.R")
+source("2_process.R")
+source("3_visualize.R")
 
-p2_targets_list <- list(
-  tar_target(
-    site_data_styled_feather, 
-    process_data(site_data,
-                 site_filename = site_info_csv,
-                 fileout = "2_process/out/site_data_styled.feather"),
-    format = "file"
-  )
-)
-
-p3_targets_list <- list(
-  tar_target(
-    figure_1_png,
-    plot_nwis_timeseries(fileout = "3_visualize/out/figure_1.png",
-                         site_data_styled_file = site_data_styled_feather,
-                         width = p_width,
-                         height = p_height,
-                         units = p_units),
-    format = "file"
-  )
-)
-
-# Return the complete list of targets
 c(p1_targets_list, p2_targets_list, p3_targets_list)


### PR DESCRIPTION
The pipeline now follows USGS conventions:

* The makefile is split into separate files per phase
* The targets names include the phase to allow for easy identification and selection of targets by phase

![targets_message_split_makefiles](https://user-images.githubusercontent.com/13890601/134196578-1683b16e-cd2a-4e94-b054-68790851275e.png)